### PR TITLE
Be no_std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,8 @@ tz-rs = { version = "^0.6.11", features = ["const"] }
 # optional dependencies
 byte-slice-cast = { version = "^1.0.0", optional = true }
 iana-time-zone = { version = "^0.1.35", optional = true }
-phf = { version = "^0.10.0", optional = true }
-phf_shared = { version = "^0.10.0", optional = true }
+phf = { version = "^0.10.0", default-features = false, optional = true }
+phf_shared = { version = "^0.10.0", default-features = false, optional = true }
 
 [dev-dependencies]
 proptest = "=1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![cfg_attr(not(test), no_std)]
 #![forbid(unsafe_code)]
 #![allow(unused_attributes)]
 #![warn(absolute_paths_not_starting_with_crate)]

--- a/src/lower.rs
+++ b/src/lower.rs
@@ -1,3 +1,5 @@
+use core::fmt;
+
 use byte_slice_cast::AsMutByteSlice;
 use phf_shared::{FmtConst, PhfBorrow, PhfHash};
 
@@ -31,7 +33,7 @@ impl PhfHash for Lower {
 }
 
 impl FmtConst for Lower {
-    fn fmt_const(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt_const(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "Lower({:#x?})", self.0)
     }
 }


### PR DESCRIPTION
Use phf without std.

Nevertheless tz-rs and iana-time-zone use features in std, so this change is kinda ... meh.