### PR TITLE
Upgrade `phf` and `phf_shared` to 0.11.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,8 @@ tz-rs = { version = "^0.6.12", features = ["const"] }
 
 # optional dependencies
 iana-time-zone = { version = "^0.1.40", optional = true }
-phf = { version = "^0.10.0", default-features = false, optional = true }
-phf_shared = { version = "^0.10.0", default-features = false, optional = true }
+phf = { version = "^0.11.0", default-features = false, optional = true }
+phf_shared = { version = "^0.11.0", default-features = false, optional = true }
 
 [dev-dependencies]
 tz-rs = { version = "^0.6.12", default-features = false, features = ["const"] }


### PR DESCRIPTION
This raises the MSRV to Rust 1.60.0 due to an upstream change in `phf`.

I couldn't find a documented minimum supported Rust version (MSRV) in this crate, but I did notice that the `Cargo.toml` metadata has the crate as 2018 edition. Is this change acceptable to the maintainers?