### PR TITLE
Update tz-rs dependency declaration to use no default features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 
 [dependencies]
 # FIXME: using "default-features = false" is a breaking change
-tz-rs = { version = "^0.6.12", features = ["const"] }
+tz-rs = { version = "^0.6.12", default-features = false, features = ["const"] }
 
 # optional dependencies
 iana-time-zone = { version = "^0.1.40", optional = true }


### PR DESCRIPTION
It looks like neither const nor std features are required to build tzdb.