### PR TITLE
Put `std` feature of `tz-rs` behind the `std` feature

### DIFF
--- a/tzdb/Cargo.toml
+++ b/tzdb/Cargo.toml
@@ -15,7 +15,7 @@ rust-version = "1.81.0"
 tzdb_data = { version = "0.2.0", default-features = false, path = "../tzdb_data" }
 
 iana-time-zone = { version = "0.1.60", default-features = false, features = ["fallback"], optional = true }
-tz-rs = { version = "0.7.0", default-features = false, features = ["std"] }
+tz-rs = { version = "0.7.0", default-features = false }
 
 [features]
 default = ["local", "now", "std"]
@@ -24,7 +24,7 @@ now = ["std"]
 # Enable functions to query the current system time:
 local = ["std", "dep:iana-time-zone"]
 # Enable the use of features in the `std` crate:
-std = ["alloc"]
+std = ["alloc", "tz-rs/std"]
 # Enable the use of features in the `alloc` crate:
 alloc = []
 


### PR DESCRIPTION
`tz-rs` is now fully `no-std`, so the `std` feature is not needed for the basic functionality.